### PR TITLE
Improve registration and admin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ http://localhost/phpmyadmin/index.php?route=/database/structure&db=sis
 ```
 
 Utilize as mesmas credenciais definidas em `config.php` (por padrão, usuário `root` sem senha). Assim é possível visualizar e editar as tabelas `schools`, `users` e `reports` diretamente pela interface web.
+
+## Executar localmente
+Após configurar o banco de dados e os arquivos do projeto, execute um servidor PHP simples apontando para a pasta `public`:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Em seguida abra `http://localhost:8000` no navegador para acessar a tela de login e realizar os cadastros.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # sis
 Sistema de acompanhamento entre Coordenadores escolares e Superintendentes
+
+Este exemplo usa PHP com MySQL para gerenciar usuários e relatórios de aulas.
+
+## Instalação
+1. Crie um banco de dados MySQL chamado `sis` e execute o arquivo `init.sql` para criar as tabelas.
+2. Ajuste as credenciais no arquivo `config.php` se necessário.
+3. A pasta `public` contém os arquivos PHP a serem servidos por um servidor web (ex: Apache).
+
+## Funcionalidades
+- Cadastro de usuários (coordenador, superintendente e administrador).
+- Login e sessão.
+- Coordenador registra data, tipo de relatório, professor acompanhado, observações e pode anexar arquivos PDF ou DOCX. Cada relatório fica salvo em `uploads/<id_da_escola>`.
+- Superintendente visualiza todos os registros de sua escola.
+- Administrador pode cadastrar ou remover escolas, gerenciar usuários e consultar todos os relatórios.
+- Coordenadores são encaminhados diretamente para o envio de relatórios após o cadastro.
+
+Este é apenas um exemplo básico para demonstrar o fluxo descrito. Em produção, lembre-se de habilitar validações adicionais e medidas de segurança.
+
+## Publicar no GitHub
+Se quiser armazenar este projeto em um repositório remoto, execute os seguintes passos:
+
+1. Crie um repositório vazio no GitHub.
+2. No terminal, adicione o remoto e envie o código:
+   ```
+   git remote add origin https://github.com/USUARIO/REPO.git
+   git push -u origin main
+   ```
+Substitua `USUARIO/REPO` pelo caminho do seu repositório.
+
+## Acessar o banco pelo phpMyAdmin
+Caso tenha o phpMyAdmin instalado localmente, é possível manipular o banco de dados usando um navegador. Acesse:
+
+```
+http://localhost/phpmyadmin/index.php?route=/database/structure&db=sis
+```
+
+Utilize as mesmas credenciais definidas em `config.php` (por padrão, usuário `root` sem senha). Assim é possível visualizar e editar as tabelas `schools`, `users` e `reports` diretamente pela interface web.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,18 @@
+<?php
+$host = 'localhost';
+$db   = 'sis';
+$user = 'root';
+$pass = '';
+$charset = 'utf8mb4';
+$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, $options);
+} catch (PDOException $e) {
+    exit('Falha na conexão: ' . $e->getMessage());
+}
+?>

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,28 @@
+CREATE TABLE schools (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin','coordinator','superintendent') NOT NULL,
+    school_id INT,
+    FOREIGN KEY (school_id) REFERENCES schools(id)
+);
+
+CREATE TABLE reports (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    coordinator_id INT NOT NULL,
+    school_id INT NOT NULL,
+    report_date DATE NOT NULL,
+    report_type VARCHAR(255),
+    teacher_name VARCHAR(255) NOT NULL,
+    notes TEXT,
+    file_path VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (coordinator_id) REFERENCES users(id),
+    FOREIGN KEY (school_id) REFERENCES schools(id)
+);

--- a/public/admin.php
+++ b/public/admin.php
@@ -1,0 +1,71 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: index.php');
+    exit;
+}
+require_once '../config.php';
+if (isset($_GET['delete_user'])) {
+    $id = (int)$_GET['delete_user'];
+    $stmt = $pdo->prepare('DELETE FROM users WHERE id = ?');
+    $stmt->execute([$id]);
+    header('Location: admin.php');
+    exit;
+}
+if (isset($_GET['delete_school'])) {
+    $id = (int)$_GET['delete_school'];
+    $stmt = $pdo->prepare('DELETE FROM schools WHERE id = ?');
+    $stmt->execute([$id]);
+    header('Location: admin.php');
+    exit;
+}
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['school_name'])) {
+    $name = trim($_POST['school_name']);
+    if ($name !== '') {
+        $stmt = $pdo->prepare('INSERT INTO schools (name) VALUES (?)');
+        $stmt->execute([$name]);
+    }
+}
+$schools = $pdo->query('SELECT * FROM schools')->fetchAll();
+$users = $pdo->query('SELECT users.id, users.name, users.email, users.role, schools.name AS school FROM users LEFT JOIN schools ON users.school_id = schools.id')->fetchAll();
+$reports = $pdo->query('SELECT reports.report_date, reports.report_type, reports.teacher_name, users.name AS coordinator, schools.name AS school FROM reports JOIN users ON reports.coordinator_id = users.id JOIN schools ON reports.school_id = schools.id ORDER BY reports.created_at DESC')->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Administração</title>
+</head>
+<body>
+    <h1>Administração</h1>
+    <p><a href="logout.php">Sair</a></p>
+    <h2>Escolas</h2>
+    <form method="post">
+        <label>Nova escola: <input type="text" name="school_name" required></label>
+        <button type="submit">Adicionar</button>
+    </form>
+    <ul>
+<?php foreach ($schools as $school): ?>
+        <li><?= htmlspecialchars($school['name']) ?>
+            <a href="?delete_school=<?= $school['id'] ?>">Excluir</a>
+        </li>
+<?php endforeach; ?>
+    </ul>
+
+    <h2>Usuários</h2>
+    <ul>
+<?php foreach ($users as $user): ?>
+        <li><?= htmlspecialchars($user['name']) ?> (<?= $user['role'] ?>) - <?= htmlspecialchars($user['email']) ?> - <?= htmlspecialchars($user['school']) ?>
+            <a href="?delete_user=<?= $user['id'] ?>">Excluir</a>
+        </li>
+<?php endforeach; ?>
+    </ul>
+
+    <h2>Relatórios</h2>
+    <ul>
+<?php foreach ($reports as $r): ?>
+        <li><?= $r['report_date'] ?> - <?= htmlspecialchars($r['teacher_name']) ?> (<?= htmlspecialchars($r['report_type']) ?>) - <?= htmlspecialchars($r['coordinator']) ?> / <?= htmlspecialchars($r['school']) ?></li>
+<?php endforeach; ?>
+    </ul>
+</body>
+</html>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+require_once '../config.php';
+$user_id = $_SESSION['user_id'];
+$role = $_SESSION['role'];
+$school_id = $_SESSION['school_id'];
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Painel</title>
+</head>
+<body>
+    <h1>Bem-vindo</h1>
+    <p><a href="logout.php">Sair</a></p>
+<?php if ($role === 'admin'): ?>
+    <p><a href="admin.php">Área administrativa</a></p>
+<?php endif; ?>
+<?php if ($role === 'coordinator'): ?>
+    <p><a href="upload_report.php">Enviar relatório</a></p>
+    <h2>Seus relatórios</h2>
+    <ul>
+<?php
+    $stmt = $pdo->prepare('SELECT report_date, report_type, teacher_name, notes, file_path FROM reports WHERE coordinator_id = ? ORDER BY created_at DESC');
+    $stmt->execute([$user_id]);
+    foreach ($stmt as $report) {
+        echo '<li>' . $report['report_date'] . ' - ' . htmlspecialchars($report['teacher_name']) . ' (' . htmlspecialchars($report['report_type']) . ') - <a href="../' . $report['file_path'] . '">arquivo</a></li>';
+    }
+?>
+    </ul>
+<?php endif; ?>
+<?php if ($role === 'superintendent'): ?>
+    <h2>Relatórios da escola</h2>
+    <ul>
+<?php
+    $stmt = $pdo->prepare('SELECT report_date, report_type, teacher_name, notes, file_path FROM reports WHERE school_id = ? ORDER BY created_at DESC');
+    $stmt->execute([$school_id]);
+    foreach ($stmt as $report) {
+        echo '<li>' . $report['report_date'] . ' - ' . htmlspecialchars($report['teacher_name']) . ' (' . htmlspecialchars($report['report_type']) . ') - <a href="../' . $report['file_path'] . '">arquivo</a></li>';
+    }
+?>
+    </ul>
+<?php endif; ?>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,23 @@
+<?php
+session_start();
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form method="post" action="login.php">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Senha: <input type="password" name="password" required></label><br>
+        <button type="submit">Entrar</button>
+    </form>
+    <p><a href="register.php">Cadastrar novo usuário</a></p>
+</body>
+</html>

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+require_once '../config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'];
+    $password = $_POST['password'];
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE email = ?');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['role'] = $user['role'];
+        $_SESSION['school_id'] = $user['school_id'];
+        header('Location: dashboard.php');
+        exit;
+    } else {
+        echo 'Credenciais inválidas.';
+    }
+}
+?>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;
+?>

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,59 @@
+<?php
+require_once '../config.php';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'];
+    $email = $_POST['email'];
+    $password = password_hash($_POST['password'], PASSWORD_DEFAULT);
+    $role = $_POST['role'];
+    $school_id = $_POST['school_id'] ?: null;
+    $stmt = $pdo->prepare('INSERT INTO users (name, email, password, role, school_id) VALUES (?,?,?,?,?)');
+    if ($stmt->execute([$name, $email, $password, $role, $school_id])) {
+        $user_id = $pdo->lastInsertId();
+        if ($role === 'coordinator') {
+            session_start();
+            $_SESSION['user_id'] = $user_id;
+            $_SESSION['role'] = $role;
+            $_SESSION['school_id'] = $school_id;
+            header('Location: upload_report.php');
+            exit;
+        } else {
+            echo 'Cadastro realizado com sucesso. <a href="index.php">Fazer login</a>';
+        }
+    } else {
+        echo 'Erro ao cadastrar.';
+    }
+    exit;
+}
+$schools = $pdo->query('SELECT id, name FROM schools')->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Cadastro</title>
+</head>
+<body>
+    <h1>Cadastrar usuário</h1>
+    <form method="post">
+        <label>Nome: <input type="text" name="name" required></label><br>
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Senha: <input type="password" name="password" required></label><br>
+        <label>Tipo:
+            <select name="role">
+                <option value="coordinator">Coordenador</option>
+                <option value="superintendent">Superintendente</option>
+                <option value="admin">Administrador</option>
+            </select>
+        </label><br>
+        <label>Escola:
+            <select name="school_id">
+                <option value="">-- selecione --</option>
+<?php foreach ($schools as $school): ?>
+                <option value="<?= $school['id'] ?>"><?= $school['name'] ?></option>
+<?php endforeach; ?>
+            </select>
+        </label><br>
+        <button type="submit">Cadastrar</button>
+    </form>
+</body>
+</html>

--- a/public/upload_report.php
+++ b/public/upload_report.php
@@ -1,0 +1,57 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'coordinator') {
+    header('Location: index.php');
+    exit;
+}
+require_once '../config.php';
+$user_id = $_SESSION['user_id'];
+$school_id = $_SESSION['school_id'];
+$uploadDir = '../uploads/' . $school_id;
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0777, true);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['report'])) {
+    $teacher = $_POST['teacher'];
+    $report_date = $_POST['report_date'];
+    $report_type = $_POST['report_type'];
+    $notes = $_POST['notes'];
+    $fileName = basename($_FILES['report']['name']);
+    $ext = strtolower(pathinfo($fileName, PATHINFO_EXTENSION));
+    if (!in_array($ext, ['pdf', 'doc', 'docx'])) {
+        echo 'Formato de arquivo inválido.';
+        exit;
+    }
+    $targetPath = $uploadDir . '/' . time() . '_' . $fileName;
+    if (move_uploaded_file($_FILES['report']['tmp_name'], $targetPath)) {
+        $relativePath = ltrim(str_replace('..', '', $targetPath), '/');
+        $stmt = $pdo->prepare('INSERT INTO reports (coordinator_id, school_id, report_date, report_type, teacher_name, notes, file_path) VALUES (?,?,?,?,?,?,?)');
+        $stmt->execute([$user_id, $school_id, $report_date, $report_type, $teacher, $notes, $relativePath]);
+        echo 'Relatório enviado com sucesso. <a href="dashboard.php">Voltar</a>';
+    } else {
+        echo 'Falha no envio do arquivo.';
+    }
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Enviar relatório</title>
+</head>
+<body>
+    <h1>Enviar relatório de aula</h1>
+    <form method="post" enctype="multipart/form-data">
+        <label>Data: <input type="date" name="report_date" required></label><br>
+        <label>Tipo de relatório: <input type="text" name="report_type"></label><br>
+        <label>Professor: <input type="text" name="teacher" required></label><br>
+        <label>Observações:<br>
+            <textarea name="notes" rows="4" cols="40"></textarea>
+        </label><br>
+        <label>Arquivo (PDF ou DOCX): <input type="file" name="report" required></label><br>
+        <button type="submit">Enviar</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- auto-login coordinators after registration for quicker reporting
- allow admins to delete users and schools
- document new admin capabilities in README
- explain how to access the MySQL database using phpMyAdmin

## Testing
- `php -l config.php`
- `php -l public/index.php`
- `php -l public/login.php`
- `php -l public/register.php`
- `php -l public/dashboard.php`
- `php -l public/upload_report.php`
- `php -l public/logout.php`
- `php -l public/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_687ffa6e022c83228d4e5b630264f982