### PR TITLE
Call session_regenerate_id after login check

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -9,6 +9,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt->execute([$email]);
     $user = $stmt->fetch();
     if ($user && password_verify($password, $user['password'])) {
+        session_regenerate_id(true);
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['role'] = $user['role'];
         $_SESSION['school_id'] = $user['school_id'];


### PR DESCRIPTION
## Summary
- regenerate the PHP session ID after a successful login

## Testing
- `php -l public/login.php`

------
https://chatgpt.com/codex/tasks/task_e_6880312efc7c83228e6141233c18ce84